### PR TITLE
Added color translation, improved code of ColorConvert.java and added…

### DIFF
--- a/src/main/java/net/frostalf/consolecolors/ColorChecker.java
+++ b/src/main/java/net/frostalf/consolecolors/ColorChecker.java
@@ -1,0 +1,28 @@
+package net.frostalf.consolecolors;
+
+public final class ColorChecker {
+
+    public final static int MIN_VALUE = 0;
+    public final static int MAX_VALUE = 256;
+
+    /**
+     * This is a utility class, it should not be instantiated in any way.
+     */
+    private ColorChecker() {
+        throw new UnsupportedOperationException("This is a utility class, hence it cannot be instantiated.");
+    }
+
+    /**
+     * Check a color code validity.
+     *
+     * @param colorCode The color code that will be checked.
+     * @throws IllegalArgumentException If the color code is smaller than {@link #MIN_VALUE} or greater than {@link #MAX_VALUE}
+     */
+    public static void checkColorCode(int colorCode) throws IllegalArgumentException {
+        if (colorCode > MAX_VALUE) {
+            throw new IllegalArgumentException(String.format("The color code used (%d) is greater than maximum limit of ", colorCode) + MAX_VALUE);
+        } else if (colorCode < MIN_VALUE) {
+            throw new IllegalArgumentException(String.format("The color code used (%d) is smaller than minimum limit of ", colorCode) + MIN_VALUE);
+        }
+    }
+}

--- a/src/main/java/net/frostalf/consolecolors/ColorConvert.java
+++ b/src/main/java/net/frostalf/consolecolors/ColorConvert.java
@@ -23,25 +23,26 @@
  */
 package net.frostalf.consolecolors;
 
+import java.util.Collection;
+
 /**
- *
  * @author Frostalf
  */
 public class ColorConvert {
+
+    public final static String RESET_SEQUENCE = "\u001b[0m";
+    public final static String COLOR_SEQUENCE = "\u001b[38;5;%dm";
 
     public ColorConvert() {
     }
 
     /**
-     *
      * @param num ANSI color code
      * @return returns hex value
      * @throws IllegalArgumentException If 8 bit number is greater than 256 or less than 0
      */
     public static String getHexValue(int num) throws IllegalArgumentException {
-        if (num > 256 || num < 0) {
-            throw new IllegalArgumentException();
-        }
+        ColorChecker.checkColorCode(num);
         int red = (num & 0x0ff) << 16;
         int green = (num & 0x0ff) << 8;
         int blue = (num & 0x0ff);
@@ -53,11 +54,10 @@ public class ColorConvert {
     }
 
     /**
-     *
      * @param hex Hex color code
      * @return returns ANSI color code
      * @throws IllegalArgumentException if hex string is greater then 6
-     * characters or doesn't contain valid rgb values
+     *                                  characters or doesn't contain valid rgb values
      */
     public static int getIntValue(String hex) throws IllegalArgumentException {
         int rgb = 0;
@@ -65,14 +65,14 @@ public class ColorConvert {
         int g = 0;
         int b = 0;
         if (hex.contains(",")) {
-            String rgbs[] = hex.split(",");
+            final String[] rgbs = hex.split(",");
             if (rgbs.length == 3) {
-                r = Integer.valueOf(rgbs[0]);
-                g = Integer.valueOf(rgbs[1]);
-                b = Integer.valueOf(rgbs[2]);
-                if(r > 256 || g > 256 || b > 256 || r < 0 || g < 0 || b < 0) {
-                    throw new IllegalArgumentException();
-                }
+                r = Integer.parseInt(rgbs[0]);
+                g = Integer.parseInt(rgbs[1]);
+                b = Integer.parseInt(rgbs[2]);
+                ColorChecker.checkColorCode(r);
+                ColorChecker.checkColorCode(g);
+                ColorChecker.checkColorCode(b);
                 rgb = 65536 * r + 256 * g + b;
             } else {
                 throw new IllegalArgumentException();
@@ -90,32 +90,61 @@ public class ColorConvert {
         int red2 = (red * 8) / 256;
         int green2 = (green * 8) / 256;
         int blue2 = (blue * 8) / 256;
-        int eightbitvalue = (red2 << 5) | (green2 << 2) | blue2;
-        return eightbitvalue;
+        return (red2 << 5) | (green2 << 2) | blue2;
+    }
+
+    public static String translateColorCode(String message, ColorPlaceholder colorPlaceholder) {
+        return message.replace(colorPlaceholder.getPlaceholder(), String.format(COLOR_SEQUENCE, colorPlaceholder.getColorReplacement()));
     }
 
     /**
+     * This method uses an array of {@link ColorPlaceholder}
+     * to replace all of the defined placeholders in any given string.
      *
-     * @param num ANSI color number
+     * @param message           The message to parse.
+     * @param colorPlaceholders The placeholders to use.
+     * @return The new message.
+     */
+    public static String translateColorCodes(String message, ColorPlaceholder... colorPlaceholders) {
+        for (ColorPlaceholder colorPlaceholder : colorPlaceholders) {
+            message = translateColorCode(message, colorPlaceholder);
+        }
+        return message;
+    }
+
+    /**
+     * This method uses a Collection of {@link ColorPlaceholder}
+     * to replace all of the defined placeholders in any given string.
+     *
+     * @param message           The message to parse.
+     * @param colorPlaceholders The placeholders to use.
+     * @return The new message.
+     */
+    public static String translateColorCodes(String message, Collection<ColorPlaceholder> colorPlaceholders) {
+        for (ColorPlaceholder colorPlaceholder : colorPlaceholders) {
+            message = translateColorCode(message, colorPlaceholder);
+        }
+        return message;
+    }
+
+    /**
+     * @param num     ANSI color number
      * @param message message to append color code
      * @return returns message with escape sequence
      * @throws IllegalArgumentException if number provided is greater than 256
      */
-    public static String escapeSecquence(int num, String message) throws IllegalArgumentException {
-        if (num > 256) {
-            throw new IllegalArgumentException();
-        }
-        return "\u001b[38;5;" + num + "m" + message + "\u001b[0m";
+    public static String escapeSequence(int num, String message) throws IllegalArgumentException {
+        ColorChecker.checkColorCode(num);
+        return "\u001b[38;5;" + num + "m" + message + RESET_SEQUENCE;
     }
 
     /**
-     *
-     * @param hex Hex color code(Either 6 character hex, or 3 number values
-     * separated with a ',') to transform to ANSI color code
+     * @param hex     Hex color code(Either 6 character hex, or 3 number values
+     *                separated with a ',') to transform to ANSI color code
      * @param message mesage to append color code
      * @return returns message with escape sequence
      */
-    public static String escapeSecquence(String hex, String message) {
-        return "\u001b[38;5;" + getIntValue(hex) + "m" + message + "\u001b[0m";
+    public static String escapeSequence(String hex, String message) {
+        return "\u001b[38;5;" + getIntValue(hex) + "m" + message + RESET_SEQUENCE;
     }
 }

--- a/src/main/java/net/frostalf/consolecolors/ColorPlaceholder.java
+++ b/src/main/java/net/frostalf/consolecolors/ColorPlaceholder.java
@@ -1,0 +1,51 @@
+package net.frostalf.consolecolors;
+
+/**
+ * A class that defines a placeholder and its associated replacement.
+ */
+public class ColorPlaceholder {
+
+    private final String placeholder;
+    private final int colorReplacement;
+
+    /**
+     * Primary constructor
+     *
+     * @param placeholder      The placeholder that will be eventually replaced with the color value.
+     * @param colorReplacement The integer color value that will be used as replacement for the placeholder.
+     */
+    public ColorPlaceholder(String placeholder, int colorReplacement) {
+        this.placeholder = placeholder;
+        this.colorReplacement = colorReplacement;
+    }
+
+    /**
+     * Secondary Constructor
+     *
+     * @param placeholder      The placeholder that will be eventually replaced with the color value.
+     * @param colorHexadecimal The hexadecimal color value that will be used as replacement for the placeholder.
+     * @throws IllegalArgumentException If the hexadecimal code is invalid.
+     */
+    public ColorPlaceholder(String placeholder, String colorHexadecimal) throws IllegalArgumentException {
+        this.placeholder = placeholder;
+        this.colorReplacement = ColorConvert.getIntValue(colorHexadecimal);
+    }
+
+    /**
+     * Get the color replacement.
+     *
+     * @return The color replacement.
+     */
+    public int getColorReplacement() {
+        return colorReplacement;
+    }
+
+    /**
+     * Get the placeholder.
+     *
+     * @return The placeholder.
+     */
+    public String getPlaceholder() {
+        return placeholder;
+    }
+}


### PR DESCRIPTION
This commit focuses on two things:
1) Improving the existing code
2) Making the end-user able to define his own placeholders and easily replace them anywhere inside the string.
---
The first point:
Several sections of the ColorConvert class used to have repeated sections of code that tried to achieve the same thing: checking if the rgb integers were below 0 or above 256. By adding the ColorChecker class, which uses the guard pattern, I removed some duplicated code and improved overall aesthetics of methods.
I've also removed hardcoded escape sequences and put them in an easily accessible variable that anyone can use.
The second point:
This "upgrade" allows users to define their own "color replacement" and use it whenever they want in any part of their strings. This makes thing like "#red I really like red, #orangebut I also like orange!" replacements very easily achievable by the users.
They can simply create two instances of replacements, with their own favorite red and orange hex code, then use them to replace the placeholders in their string with the respective placeholder. Validity check and javadocs have of course been included in all of my work.